### PR TITLE
Point rewards

### DIFF
--- a/src/app/discussions/create-topic/create-topic.component.ts
+++ b/src/app/discussions/create-topic/create-topic.component.ts
@@ -3,6 +3,7 @@ import {DbService} from '../../core/db.service';
 import {AuthService} from '../../users/auth.service';
 import {Topic} from '../../entities/topic';
 import {MatSnackBar} from '@angular/material';
+import {GamificationService, Rewards} from '../../gamification/gamification.service';
 
 @Component({
   selector: 'app-create-topic',
@@ -20,7 +21,7 @@ export class CreateTopicComponent implements OnInit {
   @Input()
   linkedQuestionId: string = null;
 
-  constructor(private auth: AuthService, private db: DbService, private snackBar: MatSnackBar) { }
+  constructor(private auth: AuthService, private db: DbService, private snackBar: MatSnackBar, private gamification: GamificationService) { }
 
   ngOnInit() {
   }
@@ -37,6 +38,8 @@ export class CreateTopicComponent implements OnInit {
       topic.linkedQuestionId = this.linkedQuestionId;
     }
     this.db.createTopic(topic).then(() => {
+      return this.gamification.reward(Rewards.TOPIC_CREATION).toPromise();
+    }).then(() => {
       this.snackBar.open(`Topic created successfully!`, 'close', {duration: 3000});
     });
     this.subjectValue = null;

--- a/src/app/discussions/create-topic/create-topic.component.ts
+++ b/src/app/discussions/create-topic/create-topic.component.ts
@@ -3,7 +3,6 @@ import {DbService} from '../../core/db.service';
 import {AuthService} from '../../users/auth.service';
 import {Topic} from '../../entities/topic';
 import {MatSnackBar} from '@angular/material';
-import {GamificationService, Rewards} from '../../gamification/gamification.service';
 
 @Component({
   selector: 'app-create-topic',

--- a/src/app/discussions/create-topic/create-topic.component.ts
+++ b/src/app/discussions/create-topic/create-topic.component.ts
@@ -21,7 +21,7 @@ export class CreateTopicComponent implements OnInit {
   @Input()
   linkedQuestionId: string = null;
 
-  constructor(private auth: AuthService, private db: DbService, private snackBar: MatSnackBar, private gamification: GamificationService) { }
+  constructor(private auth: AuthService, private db: DbService, private snackBar: MatSnackBar) { }
 
   ngOnInit() {
   }
@@ -38,8 +38,6 @@ export class CreateTopicComponent implements OnInit {
       topic.linkedQuestionId = this.linkedQuestionId;
     }
     this.db.createTopic(topic).then(() => {
-      return this.gamification.reward(Rewards.TOPIC_CREATION).toPromise();
-    }).then(() => {
       this.snackBar.open(`Topic created successfully!`, 'close', {duration: 3000});
     });
     this.subjectValue = null;

--- a/src/app/discussions/discussions.module.ts
+++ b/src/app/discussions/discussions.module.ts
@@ -9,7 +9,6 @@ import {UsersModule} from '../users/users.module';
 import {CKEditorModule} from 'ngx-ckeditor';
 import {AngularFontAwesomeModule} from 'angular-font-awesome';
 import {AppRoutingModule} from '../app-routing.module';
-import {GamificationModule} from '../gamification/gamification.module';
 
 @NgModule({
   declarations: [CommentComponent,
@@ -23,8 +22,7 @@ import {GamificationModule} from '../gamification/gamification.module';
     UsersModule,
     CKEditorModule,
     AngularFontAwesomeModule,
-    AppRoutingModule,
-    GamificationModule
+    AppRoutingModule
   ],
   exports: [
     TopicComponent,

--- a/src/app/discussions/discussions.module.ts
+++ b/src/app/discussions/discussions.module.ts
@@ -9,6 +9,7 @@ import {UsersModule} from '../users/users.module';
 import {CKEditorModule} from 'ngx-ckeditor';
 import {AngularFontAwesomeModule} from 'angular-font-awesome';
 import {AppRoutingModule} from '../app-routing.module';
+import {GamificationModule} from '../gamification/gamification.module';
 
 @NgModule({
   declarations: [CommentComponent,
@@ -23,6 +24,7 @@ import {AppRoutingModule} from '../app-routing.module';
     CKEditorModule,
     AngularFontAwesomeModule,
     AppRoutingModule,
+    GamificationModule
   ],
   exports: [
     TopicComponent,

--- a/src/app/gamification/gamification.module.ts
+++ b/src/app/gamification/gamification.module.ts
@@ -6,6 +6,7 @@ import {Planet} from './entities/planet';
 import {AngularFontAwesomeModule} from 'angular-font-awesome';
 import {UsersModule} from '../users/users.module';
 import {GamificationService} from './gamification.service';
+import {AngularFireFunctions, AngularFireFunctionsModule} from '@angular/fire/functions';
 
 const planets: Planet[] = [
   {
@@ -78,7 +79,8 @@ const planets: Planet[] = [
   imports: [
     CommonModule,
     UsersModule,
-    AngularFontAwesomeModule
+    AngularFontAwesomeModule,
+    AngularFireFunctionsModule
   ]
 })
 export class GamificationModule {

--- a/src/app/gamification/gamification.module.ts
+++ b/src/app/gamification/gamification.module.ts
@@ -5,6 +5,7 @@ import { GamePlanetComponent } from './game-planet/game-planet.component';
 import {Planet} from './entities/planet';
 import {AngularFontAwesomeModule} from 'angular-font-awesome';
 import {UsersModule} from '../users/users.module';
+import {GamificationService} from './gamification.service';
 
 const planets: Planet[] = [
   {
@@ -71,7 +72,8 @@ const planets: Planet[] = [
 @NgModule({
   declarations: [GameWorldComponent, GamePlanetComponent],
   providers: [
-    {provide: 'Planets', useValue: planets}
+    {provide: 'Planets', useValue: planets},
+    GamificationService
   ],
   imports: [
     CommonModule,

--- a/src/app/gamification/gamification.service.spec.ts
+++ b/src/app/gamification/gamification.service.spec.ts
@@ -1,0 +1,12 @@
+import { TestBed } from '@angular/core/testing';
+
+import { GamificationService } from './gamification.service';
+
+describe('GamificationService', () => {
+  beforeEach(() => TestBed.configureTestingModule({}));
+
+  it('should be created', () => {
+    const service: GamificationService = TestBed.get(GamificationService);
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/gamification/gamification.service.ts
+++ b/src/app/gamification/gamification.service.ts
@@ -2,8 +2,7 @@ import { Injectable } from '@angular/core';
 import {AngularFireFunctions} from '@angular/fire/functions';
 
 export enum Rewards {
-  SCAN_UPLOAD,
-  TOPIC_CREATION
+  SCAN_UPLOAD
 }
 
 @Injectable({
@@ -16,10 +15,7 @@ export class GamificationService {
     let pointsDelta = 0;
     switch (reward) {
       case Rewards.SCAN_UPLOAD:
-        pointsDelta = 100;
-        break;
-      case Rewards.TOPIC_CREATION:
-        pointsDelta = 10;
+        pointsDelta = 15;
         break;
       default:
         pointsDelta = 0;

--- a/src/app/gamification/gamification.service.ts
+++ b/src/app/gamification/gamification.service.ts
@@ -11,7 +11,7 @@ export enum Rewards {
 export class GamificationService {
   constructor(private fns: AngularFireFunctions) { }
 
-  public reward (reward: Rewards) {
+  public reward (reward: Rewards): Promise<void> {
     let pointsDelta = 0;
     switch (reward) {
       case Rewards.SCAN_UPLOAD:
@@ -21,6 +21,6 @@ export class GamificationService {
         pointsDelta = 0;
     }
     const callable = this.fns.httpsCallable('addPointsToUser');
-    return callable({ pointsDelta: pointsDelta });
+    return callable({ pointsDelta: pointsDelta }).toPromise();
   }
 }

--- a/src/app/gamification/gamification.service.ts
+++ b/src/app/gamification/gamification.service.ts
@@ -1,9 +1,30 @@
 import { Injectable } from '@angular/core';
+import {AngularFireFunctions} from '@angular/fire/functions';
+
+export enum Rewards {
+  SCAN_UPLOAD,
+  TOPIC_CREATION
+}
 
 @Injectable({
   providedIn: 'root'
 })
 export class GamificationService {
+  constructor(private fns: AngularFireFunctions) { }
 
-  constructor() { }
+  public reward (reward: Rewards) {
+    let pointsDelta = 0;
+    switch (reward) {
+      case Rewards.SCAN_UPLOAD:
+        pointsDelta = 100;
+        break;
+      case Rewards.TOPIC_CREATION:
+        pointsDelta = 10;
+        break;
+      default:
+        pointsDelta = 0;
+    }
+    const callable = this.fns.httpsCallable('addPointsToUser');
+    return callable({ pointsDelta: pointsDelta });
+  }
 }

--- a/src/app/gamification/gamification.service.ts
+++ b/src/app/gamification/gamification.service.ts
@@ -1,0 +1,9 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class GamificationService {
+
+  constructor() { }
+}

--- a/src/app/upload/upload.module.ts
+++ b/src/app/upload/upload.module.ts
@@ -11,6 +11,7 @@ import {AngularFontAwesomeModule} from 'angular-font-awesome';
 import {ImageCropperModule} from 'ngx-image-cropper';
 import {MatSnackBarModule} from '@angular/material';
 import {NgxSpinnerModule} from 'ngx-spinner';
+import {GamificationModule} from '../gamification/gamification.module';
 
 @NgModule({
   declarations: [
@@ -25,7 +26,8 @@ import {NgxSpinnerModule} from 'ngx-spinner';
     AngularFontAwesomeModule,
     ImageCropperModule,
     MatSnackBarModule,
-    NgxSpinnerModule
+    NgxSpinnerModule,
+    GamificationModule
   ],
   providers: [
     UploadService,

--- a/src/app/upload/upload.service.ts
+++ b/src/app/upload/upload.service.ts
@@ -5,13 +5,14 @@ import {Question} from '../entities/question';
 import {AngularFireStorage} from '@angular/fire/storage';
 import {Solution} from '../entities/solution';
 import {first} from 'rxjs/operators';
+import {GamificationService, Rewards} from '../gamification/gamification.service';
 
 @Injectable({
   providedIn: 'root'
 })
 export class UploadService {
 
-  constructor(private db: DbService, private storage: AngularFireStorage) {
+  constructor(private db: DbService, private storage: AngularFireStorage, private gamification: GamificationService) {
   }
 
   async uploadScan(course: number, year: number, semester: string, moed: string,
@@ -33,6 +34,7 @@ export class UploadService {
 
     await Promise.all(promises);
 
+    this.gamification.reward(Rewards.SCAN_UPLOAD);
   }
 
   private async uploadQuestion(course: number, year: number, semester: string, moed: string, number: number, grade: number, points: number, images: string[]) {

--- a/src/app/upload/upload.service.ts
+++ b/src/app/upload/upload.service.ts
@@ -34,7 +34,7 @@ export class UploadService {
 
     await Promise.all(promises);
 
-    this.gamification.reward(Rewards.SCAN_UPLOAD);
+    await this.gamification.reward(Rewards.SCAN_UPLOAD);
   }
 
   private async uploadQuestion(course: number, year: number, semester: string, moed: string, number: number, grade: number, points: number, images: string[]) {


### PR DESCRIPTION
As most of the points rewards are done in cloud functions (firebase triggers), this PR adds a frontend approach for adding points, for case in which we cannot you triggers (cases where we don't know the uid of the user we are adding points to).

Note for reviewers: please look at the changes made by me in the branch `feature/cloud_functions`, and provide me with a code review for them too. Thanks!